### PR TITLE
Adding bin and ibn to the compound last name list.

### DIFF
--- a/lib/parse-names.js
+++ b/lib/parse-names.js
@@ -115,7 +115,7 @@ NameParse.prototype.is_compound_lastName = function (word) {
 	// these are some common prefixes that identify a compound last names - what am I missing?
 	var words = [
 		'vere', 'von', 'van', 'de', 'del', 'della', 'di', 'da', 'pietro',
-		'vanden', 'du', 'st.', 'st', 'la', 'lo', 'ter'
+		'vanden', 'du', 'st.', 'st', 'la', 'lo', 'ter', 'bin', 'ibn'
 	];
 	return in_array(words, word);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,24 @@ var names =
 		"lastName": "Williams",
 		"suffix": ""
 	}
+}, {
+	name: "Aaron bin Omar",
+	result: {
+		"salutation": "",
+		"firstName": "Aaron",
+		"initials": "",
+		"lastName": "bin Omar",
+		"suffix": ""
+	}
+}, {
+	name: "Aaron ibn Omar",
+	result: {
+		"salutation": "",
+		"firstName": "Aaron",
+		"initials": "",
+		"lastName": "ibn Omar",
+		"suffix": ""
+	}
 }]
 
 describe('Verifiy user extraction', function() {


### PR DESCRIPTION
These are common "son of" prefixes for Arabic surnames. See
http://en.wikipedia.org/wiki/Arabic_name#Nasab
